### PR TITLE
UX: Improve blog navigation

### DIFF
--- a/src/app/blog/post/[postId]/page.tsx
+++ b/src/app/blog/post/[postId]/page.tsx
@@ -1,5 +1,6 @@
 import { getPostData } from "./utils"
 import ReactMarkdown from 'react-markdown';
+import Link from 'next/link';
 
 /**
  * Renders a post based on the provided postId.
@@ -12,9 +13,11 @@ export default function Post({ params }: { params: { postId: string } }): JSX.El
   const postId = params.postId
   const post = getPostData(postId)
   return <section>
+    <Link href="/blog" style={{ color: 'var(--secondary-color)', fontSize: '0.85em' }}>← Back to blog</Link>
     <h1 style={{ marginBottom: "32px" }}>{post.title}</h1>
     <ReactMarkdown>
       {post.content}
     </ReactMarkdown>
+    <Link href="/blog" style={{ color: 'var(--secondary-color)', fontSize: '0.85em', display: 'inline-block', marginTop: '2em', marginBottom: '2em' }}>← Back to blog</Link>
   </section>
 }

--- a/src/components/PostPreview/PostPreview.tsx
+++ b/src/components/PostPreview/PostPreview.tsx
@@ -28,7 +28,7 @@ export default function PostPreview({ title, date, content, tags, path }: Props)
   return (
     <>
       <section>
-        <h1>{title}</h1>
+        <h1><Link href={path} style={{ color: 'inherit' }}>{title}</Link></h1>
         <small>
           <span style={{ color: "#888888" }}>{date}</span>
           {(tags?.length ?? 0) > 0 && <span style={{ marginLeft: "8px", marginRight: "8px", color: "#888888" }}>|</span>}


### PR DESCRIPTION
## Summary
- **Clickable post titles**: Blog post titles on the listing page now link to the full post, styled with `color: inherit` to preserve heading appearance while gaining hover interactivity
- **Back-to-blog navigation**: Added "← Back to blog" links at the top and bottom of individual post pages, giving readers a clear way to return to the listing from either end of the page

## UX Considerations
- Post titles keep their white heading color at rest; the global orange hover effect signals clickability
- The "More >" link is retained as a secondary affordance
- Back links use `--secondary-color` and smaller font size to avoid competing with post content
- Bottom back link has `2em` vertical margin for breathing room from content and footer
- Links point to `/blog` deterministically rather than using browser history, so they work even when landing directly on a post